### PR TITLE
bug(ttl): TTL should be in the RFC3339 time format

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -239,7 +239,13 @@ func (d *Driver) TTL(keys ...string) (map[string]string, error) {
 			return nil, err
 		}
 
-		m[key] = duration.String()
+		// The command returns -2 if the key does not exist.
+		// The command returns -1 if the key exists but has no associated expire.
+		if duration == -1 || duration == -2 {
+			continue
+		}
+
+		m[key] = time.Now().Add(duration).Format(time.RFC3339)
 	}
 	return m, nil
 }


### PR DESCRIPTION
# Reason for This PR

fixes: https://github.com/roadrunner-server/roadrunner/issues/1024

## Description of Changes

- properly handle the TTL from the Redis.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
