### PR TITLE
fix: be sure that collector always initialized

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -176,6 +176,7 @@ github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZb
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -337,6 +338,7 @@ golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi
 golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.9.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=

--- a/plugin.go
+++ b/plugin.go
@@ -81,7 +81,7 @@ func (p *Plugin) KvFromConfig(key string) (kv.Storage, error) {
 
 func (p *Plugin) MetricsCollector() []prometheus.Collector {
 	p.rwm.RLock()
-	defer p.rwm.Unlock()
+	defer p.rwm.RUnlock()
 
 	if p.metricsCollector == nil {
 		return nil

--- a/plugin.go
+++ b/plugin.go
@@ -31,7 +31,7 @@ type Logger interface {
 }
 
 type Plugin struct {
-	sync.RWMutex
+	rwm sync.RWMutex
 	// config for RR integration
 	cfgPlugin Configurer
 	// logger
@@ -70,11 +70,22 @@ func (p *Plugin) KvFromConfig(key string) (kv.Storage, error) {
 		return nil, errors.E(op, err)
 	}
 
+	// should not be needed, but to double check
+	p.rwm.Lock()
+	defer p.rwm.Unlock()
+
 	p.metricsCollector = st.MetricsCollector()
 
 	return st, nil
 }
 
 func (p *Plugin) MetricsCollector() []prometheus.Collector {
+	p.rwm.RLock()
+	defer p.rwm.Unlock()
+
+	if p.metricsCollector == nil {
+		return nil
+	}
+
 	return []prometheus.Collector{p.metricsCollector}
 }


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/2172

## Description of Changes

- Metrics collector returned to the `metrics` plugin when `MetricsCollector` method was implemented. But, in our case, we returned not initialized collector when there're no Redis driver.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread safety for metrics collection, reducing the risk of race conditions and ensuring more reliable performance in concurrent environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->