### PR TITLE
chore: move the tests to the v1 kv api

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -7,7 +7,7 @@ import (
 
 	"tests/helpers"
 
-	kvProto "github.com/roadrunner-server/api-go/v6/kv/v2"
+	kvProto "github.com/roadrunner-server/api-go/v6/kv/v1"
 	"github.com/roadrunner-server/kv/v6"
 	"github.com/roadrunner-server/metrics/v6"
 	"github.com/roadrunner-server/redis/v6"
@@ -21,7 +21,7 @@ import (
 func TestGlobalSectionSuppliesAddrs(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis-global.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa"}), &kvProto.Response{}))
 	require.Equal(t, 1, has(t, client, "a"))
 }
 
@@ -45,7 +45,7 @@ func TestMetricsAreExported(t *testing.T) {
 
 	// touch the storage so the pool has stats worth reporting
 	client := helpers.NewRPCClient(t, rpcAddr)
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa"}), &kvProto.Response{}))
 
 	body := scrape(t, "http://127.0.0.1:2112/metrics")
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,17 +5,16 @@ go 1.26
 toolchain go1.26.5
 
 require (
-	github.com/roadrunner-server/api-go/v6 v6.0.0-beta.13
+	github.com/roadrunner-server/api-go/v6 v6.0.0-beta.14
 	github.com/roadrunner-server/config/v6 v6.0.0-beta.3
 	github.com/roadrunner-server/endure/v2 v2.6.2
 	github.com/roadrunner-server/goridge/v4 v4.0.0-beta.3
-	github.com/roadrunner-server/kv/v6 v6.0.0-beta.6
+	github.com/roadrunner-server/kv/v6 v6.0.0-beta.7
 	github.com/roadrunner-server/logger/v6 v6.0.0-beta.3
-	github.com/roadrunner-server/metrics/v6 v6.0.0-beta.5
+	github.com/roadrunner-server/metrics/v6 v6.0.0-beta.6
 	github.com/roadrunner-server/redis/v6 v6.0.0
 	github.com/roadrunner-server/rpc/v6 v6.0.0-beta.5
 	github.com/stretchr/testify v1.11.1
-	google.golang.org/protobuf v1.36.12
 )
 
 replace github.com/roadrunner-server/redis/v6 => ../
@@ -64,5 +63,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
+	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -63,8 +63,8 @@ github.com/redis/go-redis/extra/redisprometheus/v9 v9.22.0 h1:jmk+No4xN5dtzSsB1P
 github.com/redis/go-redis/extra/redisprometheus/v9 v9.22.0/go.mod h1:mjtJ1m5XQz30PCx3wa3Tbda7EArYzdA1LsFe3g7ghB4=
 github.com/redis/go-redis/v9 v9.22.0 h1:laDvpYXTJtZLloinw1fA5Kqd6HAEH2XKxOkG/PDq2F0=
 github.com/redis/go-redis/v9 v9.22.0/go.mod h1:y2g0Wj8rQvuK0ELM+oxSudcLtC09JScs98I/X9gRWY4=
-github.com/roadrunner-server/api-go/v6 v6.0.0-beta.13 h1:BAV1aKkRp51C1OXDfEYZXgfrXqn4O7bpr6Z/m5otwd8=
-github.com/roadrunner-server/api-go/v6 v6.0.0-beta.13/go.mod h1:Y4rsabWjr4Y10Jg6H8J5NDitQqlnXmGhCdgR+zyLYkI=
+github.com/roadrunner-server/api-go/v6 v6.0.0-beta.14 h1:sTskv/3ImOZlUdtHuj9uT24gm1gQl/qU8rFNvn3MzhU=
+github.com/roadrunner-server/api-go/v6 v6.0.0-beta.14/go.mod h1:Y4rsabWjr4Y10Jg6H8J5NDitQqlnXmGhCdgR+zyLYkI=
 github.com/roadrunner-server/api-plugins/v6 v6.0.0-beta.2 h1:GqsZzWQ5jMXRF1O/b8IqFz9PLpS7Ui0K4OyACLql2MI=
 github.com/roadrunner-server/api-plugins/v6 v6.0.0-beta.2/go.mod h1:2v4yUK5Kvbvq8C3IkDoBkuamq9h+7i/JLjyf7k1j5JM=
 github.com/roadrunner-server/config/v6 v6.0.0-beta.3 h1:G0EUzJ6Yw4UnleM6BhnOBbYPXKDHRmCJiGhC3nXDBwI=
@@ -75,12 +75,12 @@ github.com/roadrunner-server/errors v1.5.0 h1:unG7LKIZrSzkCCF3YLRLA5VyqE0KKomofX
 github.com/roadrunner-server/errors v1.5.0/go.mod h1:g9fo/T2C13cWRDR9PW1r0ZAOSQfNhWAZawyfkGiaHuI=
 github.com/roadrunner-server/goridge/v4 v4.0.0-beta.3 h1:+kUw00/fpqwdMWrPMYW+OZH3O4gEar8hqrY7I+nAztA=
 github.com/roadrunner-server/goridge/v4 v4.0.0-beta.3/go.mod h1:1aHppV68y/VqRED/AsfNg59sft9aQOhqgr5Z5n49jbM=
-github.com/roadrunner-server/kv/v6 v6.0.0-beta.6 h1:qU6j1xXzJeuOyrd9DyNIApYA5D4HvFAQfxhgDR13hO8=
-github.com/roadrunner-server/kv/v6 v6.0.0-beta.6/go.mod h1:o1TLqxL7Scg8El+ysXDCpN2KQztEFMOButxWI+zgY5c=
+github.com/roadrunner-server/kv/v6 v6.0.0-beta.7 h1:vIFyrCgkjSArpq5itfogHrPCJltmDoavIeLX6Y069Q0=
+github.com/roadrunner-server/kv/v6 v6.0.0-beta.7/go.mod h1:zKXssJqwU2JT+z3R/xYQNZ3VslsnYbUaYhfayaZD2Mk=
 github.com/roadrunner-server/logger/v6 v6.0.0-beta.3 h1:eoJKXAUSyykDfVX6eTUhmAn6Y8pS/LyI5fDP4H+G5rQ=
 github.com/roadrunner-server/logger/v6 v6.0.0-beta.3/go.mod h1:MwHb3AbltHYtu7nRpml5NeYu7O+W8rCpDBeNTTEoE1M=
-github.com/roadrunner-server/metrics/v6 v6.0.0-beta.5 h1:JaJGPwjVKDUJi0Ey3ztkjhod1EYHbmf8gmdPoYWCWbo=
-github.com/roadrunner-server/metrics/v6 v6.0.0-beta.5/go.mod h1:VAY+k1uFqySbt9E9RaGQXXN+Pn0D2cuJEpO0i66Ny2M=
+github.com/roadrunner-server/metrics/v6 v6.0.0-beta.6 h1:rr5joyN+uHmxP3096UD+om254hPnC76FH4q7XkGfhHE=
+github.com/roadrunner-server/metrics/v6 v6.0.0-beta.6/go.mod h1:sKXXkrSklam6/sbUvnHoCkzXjnoFcdVKe49MZprtHcc=
 github.com/roadrunner-server/rpc/v6 v6.0.0-beta.5 h1:FjwXfznbmyCEKFUHkxnvK8yo1HQKAQk+7fiPhSYC27E=
 github.com/roadrunner-server/rpc/v6 v6.0.0-beta.5/go.mod h1:z387hZZOEJ3+bB8iW1PEAEXF3jUUb/dDLDnVSc1CNNQ=
 github.com/roadrunner-server/tcplisten v1.5.2 h1:nn8yXYrhRDkfQ9AAu4V075uT4fZRmOnpxkawgE+bWPA=

--- a/tests/kv_test.go
+++ b/tests/kv_test.go
@@ -7,12 +7,11 @@ import (
 
 	"tests/helpers"
 
-	kvProto "github.com/roadrunner-server/api-go/v6/kv/v2"
+	kvProto "github.com/roadrunner-server/api-go/v6/kv/v1"
 	"github.com/roadrunner-server/kv/v6"
 	"github.com/roadrunner-server/redis/v6"
 	rpcPlugin "github.com/roadrunner-server/rpc/v6"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -38,23 +37,23 @@ func bootKV(t *testing.T, cfgPath, addr string) *rpc.Client {
 	helpers.Start(t, cfgPath, redisPlugins(), helpers.WithTCPProbe(addr))
 
 	client := helpers.NewRPCClient(t, addr)
-	require.NoError(t, client.Call("kv.Clear", &kvProto.KvRequest{Storage: storage}, &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Clear", &kvProto.Request{Storage: storage}, &kvProto.Response{}))
 
 	return client
 }
 
-func items(pairs map[string]string) *kvProto.KvRequest {
-	req := &kvProto.KvRequest{Storage: storage}
+func items(pairs map[string]string) *kvProto.Request {
+	req := &kvProto.Request{Storage: storage}
 	for k, v := range pairs {
-		req.Items = append(req.Items, &kvProto.KvItem{Key: k, Value: []byte(v)})
+		req.Items = append(req.Items, &kvProto.Item{Key: k, Value: []byte(v)})
 	}
 	return req
 }
 
-func keys(names ...string) *kvProto.KvRequest {
-	req := &kvProto.KvRequest{Storage: storage}
+func keys(names ...string) *kvProto.Request {
+	req := &kvProto.Request{Storage: storage}
 	for _, n := range names {
-		req.Items = append(req.Items, &kvProto.KvItem{Key: n})
+		req.Items = append(req.Items, &kvProto.Item{Key: n})
 	}
 	return req
 }
@@ -63,7 +62,7 @@ func keys(names ...string) *kvProto.KvRequest {
 func has(t *testing.T, client *rpc.Client, names ...string) int {
 	t.Helper()
 
-	resp := &kvProto.KvResponse{}
+	resp := &kvProto.Response{}
 	require.NoError(t, client.Call("kv.Has", keys(names...), resp))
 
 	return len(resp.GetItems())
@@ -72,7 +71,7 @@ func has(t *testing.T, client *rpc.Client, names ...string) int {
 func TestSetAndHas(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
 
 	require.Equal(t, 2, has(t, client, "a", "b"))
 	require.Equal(t, 0, has(t, client, "missing"))
@@ -81,9 +80,9 @@ func TestSetAndHas(t *testing.T) {
 func TestMGetReturnsStoredValues(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
 
-	resp := &kvProto.KvResponse{}
+	resp := &kvProto.Response{}
 	require.NoError(t, client.Call("kv.MGet", keys("a", "b", "absent"), resp))
 
 	got := make(map[string]string, len(resp.GetItems()))
@@ -97,8 +96,8 @@ func TestMGetReturnsStoredValues(t *testing.T) {
 func TestDeleteRemovesOnlyTheNamedKey(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
-	require.NoError(t, client.Call("kv.Delete", keys("a"), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
+	require.NoError(t, client.Call("kv.Delete", keys("a"), &kvProto.Response{}))
 
 	require.Equal(t, 0, has(t, client, "a"))
 	require.Equal(t, 1, has(t, client, "b"))
@@ -107,8 +106,8 @@ func TestDeleteRemovesOnlyTheNamedKey(t *testing.T) {
 func TestClearEmptiesTheStorage(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
-	require.NoError(t, client.Call("kv.Clear", &kvProto.KvRequest{Storage: storage}, &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
+	require.NoError(t, client.Call("kv.Clear", &kvProto.Request{Storage: storage}, &kvProto.Response{}))
 
 	require.Equal(t, 0, has(t, client, "a", "b"))
 }
@@ -119,22 +118,24 @@ func TestClearEmptiesTheStorage(t *testing.T) {
 func TestTTLReportsRemainingLifetime(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	req := &kvProto.KvRequest{
+	req := &kvProto.Request{
 		Storage: storage,
-		Items: []*kvProto.KvItem{
+		Items: []*kvProto.Item{
 			{Key: "permanent", Value: []byte("v")},
-			{Key: "ephemeral", Value: []byte("v"), Ttl: durationpb.New(time.Minute)},
+			{Key: "ephemeral", Value: []byte("v"), Timeout: time.Now().UTC().Add(time.Minute).Format(time.RFC3339)},
 		},
 	}
-	require.NoError(t, client.Call("kv.Set", req, &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", req, &kvProto.Response{}))
 
-	resp := &kvProto.KvResponse{}
+	resp := &kvProto.Response{}
 	require.NoError(t, client.Call("kv.TTL", keys("permanent", "ephemeral"), resp))
 
 	// the driver skips keys with no expiry, so only the ephemeral one comes back
 	require.Len(t, resp.GetItems(), 1)
 	require.Equal(t, "ephemeral", resp.GetItems()[0].GetKey())
-	require.Positive(t, resp.GetItems()[0].GetTtl().AsDuration(), "a key with a TTL must report a remaining lifetime")
+	expiry, err := time.Parse(time.RFC3339, resp.GetItems()[0].GetTimeout())
+	require.NoError(t, err)
+	require.True(t, expiry.After(time.Now()), "a key with a TTL must report a future expiry")
 }
 
 // TestKeyExpiresAfterTTL polls for the expiry rather than sleeping out the
@@ -142,14 +143,14 @@ func TestTTLReportsRemainingLifetime(t *testing.T) {
 func TestKeyExpiresAfterTTL(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	req := &kvProto.KvRequest{
+	req := &kvProto.Request{
 		Storage: storage,
-		Items: []*kvProto.KvItem{
+		Items: []*kvProto.Item{
 			{Key: "permanent", Value: []byte("v")},
-			{Key: "ephemeral", Value: []byte("v"), Ttl: durationpb.New(shortTTL)},
+			{Key: "ephemeral", Value: []byte("v"), Timeout: time.Now().UTC().Add(shortTTL).Format(time.RFC3339)},
 		},
 	}
-	require.NoError(t, client.Call("kv.Set", req, &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", req, &kvProto.Response{}))
 	require.Equal(t, 2, has(t, client, "permanent", "ephemeral"))
 
 	require.Eventually(t, func() bool {
@@ -162,16 +163,16 @@ func TestKeyExpiresAfterTTL(t *testing.T) {
 func TestMExpireAppliesTTLToExistingKeys(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
 
-	expire := &kvProto.KvRequest{
+	expire := &kvProto.Request{
 		Storage: storage,
-		Items: []*kvProto.KvItem{
-			{Key: "a", Ttl: durationpb.New(shortTTL)},
-			{Key: "b", Ttl: durationpb.New(shortTTL)},
+		Items: []*kvProto.Item{
+			{Key: "a", Timeout: time.Now().UTC().Add(shortTTL).Format(time.RFC3339)},
+			{Key: "b", Timeout: time.Now().UTC().Add(shortTTL).Format(time.RFC3339)},
 		},
 	}
-	require.NoError(t, client.Call("kv.MExpire", expire, &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.MExpire", expire, &kvProto.Response{}))
 
 	require.Eventually(t, func() bool {
 		return has(t, client, "a", "b") == 0
@@ -181,10 +182,10 @@ func TestMExpireAppliesTTLToExistingKeys(t *testing.T) {
 func TestUnknownStorageIsRejected(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis.yaml", rpcAddr)
 
-	err := client.Call("kv.Has", &kvProto.KvRequest{
+	err := client.Call("kv.Has", &kvProto.Request{
 		Storage: "not-configured",
-		Items:   []*kvProto.KvItem{{Key: "a"}},
-	}, &kvProto.KvResponse{})
+		Items:   []*kvProto.Item{{Key: "a"}},
+	}, &kvProto.Response{})
 
 	require.Error(t, err)
 }

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -3,7 +3,7 @@ package kv
 import (
 	"testing"
 
-	kvProto "github.com/roadrunner-server/api-go/v6/kv/v2"
+	kvProto "github.com/roadrunner-server/api-go/v6/kv/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,11 +13,11 @@ import (
 func TestTLSConnection(t *testing.T) {
 	client := bootKV(t, "configs/.rr-redis-tls.yaml", rpcTLSAddr)
 
-	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.KvResponse{}))
+	require.NoError(t, client.Call("kv.Set", items(map[string]string{"a": "aa", "b": "bb"}), &kvProto.Response{}))
 
 	require.Equal(t, 2, has(t, client, "a", "b"))
 
-	resp := &kvProto.KvResponse{}
+	resp := &kvProto.Response{}
 	require.NoError(t, client.Call("kv.MGet", keys("a"), resp))
 	require.Len(t, resp.GetItems(), 1)
 	require.Equal(t, "aa", string(resp.GetItems()[0].GetValue()))


### PR DESCRIPTION
kv/v1 protos (`Request`/`Item`, RFC3339 expiry strings instead of duration TTLs), on the freshly tagged kv v6.0.0-beta.7 and metrics v6.0.0-beta.6. Full suite green locally, TLS included.